### PR TITLE
Run Filet without ramdisk

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM filecoin/lily:v0.12.0
 
 # Install aria2
 RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
-    && apt-get -y install --no-install-recommends aria2
+    && apt-get -y install --no-install-recommends aria2 zstd
 
 # Install gcloud
 RUN echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] http://packages.cloud.google.com/apt cloud-sdk main" | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list && curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key --keyring /usr/share/keyrings/cloud.google.gpg  add - && apt-get update -y && apt-get install google-cloud-cli -y

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 .DEFAULT_GOAL := run
 
-VERSION=v0.3.5
+VERSION=v0.4.0
 IMAGE=europe-west1-docker.pkg.dev/protocol-labs-data/pl-data/filet
 
 build:

--- a/gce_batch_job.json
+++ b/gce_batch_job.json
@@ -5,11 +5,11 @@
                 "runnables": [
                     {
                         "container": {
-                            "imageUri": "europe-west1-docker.pkg.dev/protocol-labs-data/pl-data/filet:v0.3.4",
+                            "imageUri": "europe-west1-docker.pkg.dev/protocol-labs-data/pl-data/filet:v0.4.0",
                             "volumes": [
                                 "/mnt/share:/gcs"
                             ],
-                            "options": "--privileged --tmpfs /ram -e REPO_PATH=/ram/.lily"
+                            "options": "--privileged -e LILY_BLOCKSTORE_CACHE_SIZE=2000000 -e LILY_STATESTORE_CACHE_SIZE=800000"
                         }
                     },
                     {
@@ -20,8 +20,8 @@
                 ],
                 "computeResource": {
                     "cpuMilli": 48000,
-                    "memoryMib": 183105,
-                    "boot_disk_mib": 190735
+                    "memoryMib": 190000,
+                    "boot_disk_mib": 300000
                 },
                 "volumes": [
                     {

--- a/scripts/walk.sh
+++ b/scripts/walk.sh
@@ -5,21 +5,30 @@
 
 set -eox pipefail
 
+export GOLOG_LOG_FMT=json
+
 SNAPSHOT_URL="${1:-"https://snapshots.mainnet.filops.net/minimal/latest"}"
 REPO_PATH="${REPO_PATH:-"/var/lib/lily"}"
 WALK_EPOCHS="${WALK_EPOCHS:-"400"}"
 
 echo "Initializing Lily repository with ${SNAPSHOT_URL}"
 
+# Download the snapshot
 aria2c -x16 -s16 "${SNAPSHOT_URL}" -d /tmp
 
-export GOLOG_LOG_FMT=json
+# If the snapshot is compressed, extract it.
+if [[ "${SNAPSHOT_URL}" == *.zst ]]; then
+  unzstd /tmp/*.car.zst
+fi
 
+# Start Lily
 lily init --config /lily/config.toml --repo "${REPO_PATH}" --import-snapshot /tmp/*.car
 nohup lily daemon --repo="${REPO_PATH}" --config=/lily/config.toml --bootstrap=false &> out.log &
 
+# Wait for Lily to come online
 lily wait-api
 
+# Extract walk epochs from the snapshot
 CAR_FILE_NAME=$(find /tmp/*.car -maxdepth 1 -print0 | xargs -0 -n1 basename)
 TO_EPOCH=${CAR_FILE_NAME%%_*}
 FROM_EPOCH=$((TO_EPOCH - WALK_EPOCHS))
@@ -28,8 +37,10 @@ echo "Walking from epoch ${FROM_EPOCH} to ${TO_EPOCH}"
 
 sleep 10
 
+# Run job
 lily job run --storage=CSV walk --from "${FROM_EPOCH}" --to "${TO_EPOCH}"
 
+# Wait for job to finish
 lily job wait --id 1 && lily stop
 
 ls -lh /tmp/data


### PR DESCRIPTION
Since the differences between running with a RAM disk or not are very small, we can make the requirements lighter and get better price and faster spot machine allocations. 

Closes #12.