### PR TITLE
refactor: docker best practices

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,17 +1,15 @@
 FROM filecoin/lily:v0.12.0
 
-# Install aria2
-RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
+# Install aria2 and gcloud
+RUN echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] http://packages.cloud.google.com/apt cloud-sdk main" | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list && curl https://packages.cloud.google.com/ \
+    && apt-get update && export DEBIAN_FRONTEND=noninteractive \
     && apt-get -y install --no-install-recommends aria2 zstd
-
-# Install gcloud
-RUN echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] http://packages.cloud.google.com/apt cloud-sdk main" | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list && curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key --keyring /usr/share/keyrings/cloud.google.gpg  add - && apt-get update -y && apt-get install google-cloud-cli -y
 
 # Add required files
 COPY config.toml scripts gce_batch_job.json /lily/
 
 # Create data folder
-RUN mkdir /tmp/data
+WORKDIR /tmp/data
 
 # Run script
 ENTRYPOINT [ "/bin/bash" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,11 @@
 FROM filecoin/lily:v0.12.0
 
 # Install aria2 and gcloud
-RUN echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] http://packages.cloud.google.com/apt cloud-sdk main" | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list && curl https://packages.cloud.google.com/ \
-    && apt-get update && export DEBIAN_FRONTEND=noninteractive \
-    && apt-get -y install --no-install-recommends aria2 zstd
+RUN echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] http://packages.cloud.google.com/apt cloud-sdk main" | \
+    tee -a /etc/apt/sources.list.d/google-cloud-sdk.list && curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | \
+    apt-key --keyring /usr/share/keyrings/cloud.google.gpg add - && \
+    apt-get update -y && \
+    apt-get -y install --no-install-recommends aria2 zstd google-cloud-cli
 
 # Add required files
 COPY config.toml scripts gce_batch_job.json /lily/


### PR DESCRIPTION
- Use one `RUN` command instead of 2 to install dependencies. This means one less layer to create and cache.
  - https://docs.docker.com/develop/develop-images/dockerfile_best-practices/#run
- Use `WORKDIR` instead of `RUN mkdir` because it's more readable.
  - https://docs.docker.com/develop/develop-images/dockerfile_best-practices/#workdir
  - https://docs.docker.com/engine/reference/builder/#workdir