### PR TITLE
Mount archival snapshot bucket

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 .DEFAULT_GOAL := run
 
-VERSION=v0.5.1
+VERSION=v0.5.2
 IMAGE=europe-west1-docker.pkg.dev/protocol-labs-data/pl-data/filet
 
 build:
@@ -20,5 +20,5 @@ clean:
 	sudo rm -rf .lily
 	rm -rf *.car *.aria2
 
-send:
+send: push
 	gcloud --billing-project protocol-labs-data beta batch jobs submit lily-job-gcs-backfill-$(shell date +%s) --config gce_batch_job.json --location europe-north1

--- a/gce_batch_job.json
+++ b/gce_batch_job.json
@@ -5,13 +5,14 @@
                 "runnables": [
                     {
                         "container": {
-                            "imageUri": "europe-west1-docker.pkg.dev/protocol-labs-data/pl-data/filet:v0.5.0.backfill",
+                            "imageUri": "europe-west1-docker.pkg.dev/protocol-labs-data/pl-data/filet:v0.5.2",
                             "volumes": [
-                                "/mnt/share:/gcs"
+                                "/mnt/share:/gcs",
+                                "/mnt/snapshots/historical-exports:/snapshots"
                             ],
                             "entrypoint": "/lily/export.sh",
                             "commands": [
-                                "/gcs/snapshot_0_2882_1666948118.car.zst",
+                                "/snapshots/snapshot_0_2882_1666948118.car.zst",
                                 "/gcs/backfill/"
                             ],
                             "options": "--privileged -e LILY_BLOCKSTORE_CACHE_SIZE=2000000 -e LILY_STATESTORE_CACHE_SIZE=800000"
@@ -34,6 +35,12 @@
                             "remotePath": "pl-data-temp"
                         },
                         "mountPath": "/mnt/share"
+                    },
+                    {
+                        "gcs": {
+                            "remotePath": "fil-mainnet-archival-snapshots"
+                        },
+                        "mountPath": "/mnt/snapshots"
                     }
                 ],
                 "maxRetryCount": 1,


### PR DESCRIPTION
With these changes, Batch is able to read and start processing the snapshots on the bucket. It'll read the snapshot and use `sentinel-archiver` to generate the CSVs.

Right now, the execution is not completing properly due to `sentinel-archiver` hanging out.

