### PR TITLE
chore: jobname-table file pattern for csv

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -4,4 +4,4 @@
             Format = "CSV"
             Path = "/tmp/data"
             OmitHeader = false
-            FilePattern = "{table}.csv"
+            FilePattern = "{jobname}-{table}.csv"


### PR DESCRIPTION
sentinel-archiver needs a `{jobname}-{table}` format