### PR TITLE
chore: increase API.Timeout

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -1,3 +1,6 @@
+[API]
+    Timeout = "5m"
+
 [Storage]
     [Storage.File]
         [Storage.File.CSV]


### PR DESCRIPTION
This should decrease/get rid of the websocket connection closed (1000) log message by keeping the socket alive.

This is passed through [these lines here by getting a full node API](https://github.com/filecoin-project/lotus/blob/master/cmd/lotus-health/main.go#L92-L98) and if you step through the definitions, you'll end up [where they create a jsonrpc client](https://github.com/filecoin-project/lotus/blob/048ccc71bbf7d3003603d714b62dc0f0c79a2a36/api/client/client.go#L28) which uses [go-jsonrpc](https://github.com/filecoin-project/lotus/blob/048ccc71bbf7d3003603d714b62dc0f0c79a2a36/api/client/client.go#L10).