### PR TITLE
chore: add billing project for public bucket

### DIFF
--- a/gce_batch_job.json
+++ b/gce_batch_job.json
@@ -40,7 +40,10 @@
                         "gcs": {
                             "remotePath": "fil-mainnet-archival-snapshots"
                         },
-                        "mountPath": "/mnt/snapshots"
+                        "mountPath": "/mnt/snapshots",
+                        "mountOptions:" [
+                            "--billing-project protocol-labs-data",
+                        ]
                     }
                 ],
                 "maxRetryCount": 0,

--- a/gce_batch_job.json
+++ b/gce_batch_job.json
@@ -41,7 +41,7 @@
                             "remotePath": "fil-mainnet-archival-snapshots"
                         },
                         "mountPath": "/mnt/snapshots",
-                        "mountOptions:" [
+                        "mountOptions": [
                             "--billing-project protocol-labs-data",
                         ]
                     }


### PR DESCRIPTION
To use a public bucket with requester pays enabled, we need to pass a billing project to the GCS mount. This is achieved through the `mountOptions[]` field:

https://cloud.google.com/batch/docs/reference/rest/v1/projects.locations.jobs#volume