### PR TITLE
chore: eu region for compute

### DIFF
--- a/scripts/send_export_jobs.sh
+++ b/scripts/send_export_jobs.sh
@@ -25,6 +25,6 @@ for SNAPSHOT in ${SNAPSHOT_LIST}; do
         # Pad the epoch with 0s to 10 digits
         PADDED_SNAPSHOT_EPOCH_FROM=$(printf "%07d" "$SNAPSHOT_EPOCH_FROM")
         PADDED_SNAPSHOT_EPOCH_TO=$(printf "%07d" "$SNAPSHOT_EPOCH_TO")
-        envsubst < gce_batch_job.json | gcloud --billing-project protocol-labs-data beta batch jobs submit lily-snapshot-"$PADDED_SNAPSHOT_EPOCH_FROM"-"$PADDED_SNAPSHOT_EPOCH_TO"-"$(date +%s)" --location us-central1 --config=-
+        envsubst < gce_batch_job.json | gcloud --billing-project protocol-labs-data beta batch jobs submit lily-snapshot-"$PADDED_SNAPSHOT_EPOCH_FROM"-"$PADDED_SNAPSHOT_EPOCH_TO"-"$(date +%s)" --location europe-north1 --config=-
     fi
 done


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/3408478/214808949-f06debd3-c8ad-4372-bbdf-874bcb4a2c54.png)

Previous commit of this change says that the snapshots are in a bucket located in the US but upon closer inspection it's the EU 🤔 I think it makes more sense to colocate the compute back to the same region the bucket is in for cost.